### PR TITLE
Allow custom annotations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,6 +61,7 @@ resource "kubernetes_deployment" "alb_ingress_controller" {
     template {
       metadata {
         labels = local.kubernetes_deployment_labels
+        annotations = var.kubernetes_deployment_annotations
       }
 
       spec {

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,12 @@ variable "kubernetes_deployment_image_tag" {
   default = "v1.1.4"
 }
 
+variable "kubernetes_deployment_annotations" {
+  type = map(string)
+  default = {}
+  description = "Annotations for pod template"
+}
+
 variable "kubernetes_deployment_node_selector" {
   type = map(string)
   default = {}


### PR DESCRIPTION
The use case behind this is to allow for the "iam.amazonaws.com/role" annotation, so that kube2iam can assign the correct role to the pod